### PR TITLE
Fetch running processes & pass to front-end

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,4 +1,5 @@
 const { app, BrowserWindow, ipcMain } = require("electron");
+const psList = require("ps-list");
 
 function createWindow() {
     // Create the browser window.
@@ -17,11 +18,20 @@ function createWindow() {
 
     // Listen for the front-end web app to send a request that asks for what
     // processes are running on the user's machine.
-    ipcMain.on("processesRequest", (event, _arg) =>
-        // TODO: use node's APIs to find all running processes.
-        // For now, we'll just send a dummy list of fake process names.
-        event.reply("processesReply", ["spotify", "mail", "safari"]),
-    );
+    ipcMain.handle("processesRequest", async (_event, ..._args) => {
+        try {
+            let processesList = await psList();
+            return processesList.map(
+                (process) => `${process.name} (PID: ${process.pid})`,
+            );
+        } catch (err) {
+            // TODO: better error handling strategy.
+            return [
+                "An error occurred when fetching the running processes on your machine",
+                err.message,
+            ];
+        }
+    });
 }
 
 app.whenReady().then(createWindow);

--- a/main.js
+++ b/main.js
@@ -15,10 +15,10 @@ function createWindow() {
 
     // and load the index.html of the app.
     win.loadURL("http://localhost:3000");
-
-    // Listen for the front-end web app to send a request that asks for what
-    // processes are running on the user's machine.
-    ipcMain.handle("processesRequest", async () => psList());
 }
 
 app.whenReady().then(createWindow);
+
+// Listen for the front-end web app to send a request that asks for what
+// processes are running on the user's machine.
+ipcMain.handle("processesRequest", async () => psList());

--- a/main.js
+++ b/main.js
@@ -18,20 +18,7 @@ function createWindow() {
 
     // Listen for the front-end web app to send a request that asks for what
     // processes are running on the user's machine.
-    ipcMain.handle("processesRequest", async (_event, ..._args) => {
-        try {
-            let processesList = await psList();
-            return processesList.map(
-                (process) => `${process.name} (PID: ${process.pid})`,
-            );
-        } catch (err) {
-            // TODO: better error handling strategy.
-            return [
-                "An error occurred when fetching the running processes on your machine",
-                err.message,
-            ];
-        }
-    });
+    ipcMain.handle("processesRequest", async () => psList());
 }
 
 app.whenReady().then(createWindow);

--- a/main.js
+++ b/main.js
@@ -1,17 +1,27 @@
-const { app, BrowserWindow } = require("electron");
+const { app, BrowserWindow, ipcMain } = require("electron");
 
 function createWindow() {
     // Create the browser window.
     const win = new BrowserWindow({
         width: 800,
         height: 900,
-        webPreferences: {},
+        webPreferences: {
+            nodeIntegration: true,
+        },
         icon: "tokspace.png",
         title: "TokSpace",
     });
 
     // and load the index.html of the app.
     win.loadURL("http://localhost:3000");
+
+    // Listen for the front-end web app to send a request that asks for what
+    // processes are running on the user's machine.
+    ipcMain.on("processesRequest", (event, _arg) =>
+        // TODO: use node's APIs to find all running processes.
+        // For now, we'll just send a dummy list of fake process names.
+        event.reply("processesReply", ["spotify", "mail", "safari"]),
+    );
 }
 
 app.whenReady().then(createWindow);

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,9 +13,9 @@
             }
         },
         "@babel/compat-data": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.10.4.tgz",
-            "integrity": "sha512-t+rjExOrSVvjQQXNp5zAIYDp00KjdvGl/TpDX5REPr0S9IAIPQMTilcfG6q8c0QFmj9lSTVySV2VTsyggvtNIw==",
+            "version": "7.10.5",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.10.5.tgz",
+            "integrity": "sha512-mPVoWNzIpYJHbWje0if7Ck36bpbtTvIxOi9+6WSK9wjGEXearAqlwBoTQvVjsAY2VIwgcs8V940geY3okzRCEw==",
             "requires": {
                 "browserslist": "^4.12.0",
                 "invariant": "^2.2.4",
@@ -60,13 +60,12 @@
             }
         },
         "@babel/generator": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.10.4.tgz",
-            "integrity": "sha512-toLIHUIAgcQygFZRAQcsLQV3CBuX6yOIru1kJk/qqqvcRmZrYe6WavZTSG+bB8MxhnL9YPf+pKQfuiP161q7ng==",
+            "version": "7.10.5",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.10.5.tgz",
+            "integrity": "sha512-3vXxr3FEW7E7lJZiWQ3bM4+v/Vyr9C+hpolQ8BGFr9Y8Ri2tFLWTixmwKBafDujO1WVah4fhZBeU1bieKdghig==",
             "requires": {
-                "@babel/types": "^7.10.4",
+                "@babel/types": "^7.10.5",
                 "jsesc": "^2.5.1",
-                "lodash": "^4.17.13",
                 "source-map": "^0.5.0"
             }
         },
@@ -97,13 +96,13 @@
             }
         },
         "@babel/helper-builder-react-jsx-experimental": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx-experimental/-/helper-builder-react-jsx-experimental-7.10.4.tgz",
-            "integrity": "sha512-LyacH/kgQPgLAuaWrvvq1+E7f5bLyT8jXCh7nM67sRsy2cpIGfgWJ+FCnAKQXfY+F0tXUaN6FqLkp4JiCzdK8Q==",
+            "version": "7.10.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx-experimental/-/helper-builder-react-jsx-experimental-7.10.5.tgz",
+            "integrity": "sha512-Buewnx6M4ttG+NLkKyt7baQn7ScC/Td+e99G914fRU8fGIUivDDgVIQeDHFa5e4CRSJQt58WpNHhsAZgtzVhsg==",
             "requires": {
                 "@babel/helper-annotate-as-pure": "^7.10.4",
                 "@babel/helper-module-imports": "^7.10.4",
-                "@babel/types": "^7.10.4"
+                "@babel/types": "^7.10.5"
             }
         },
         "@babel/helper-compilation-targets": {
@@ -126,12 +125,12 @@
             }
         },
         "@babel/helper-create-class-features-plugin": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.10.4.tgz",
-            "integrity": "sha512-9raUiOsXPxzzLjCXeosApJItoMnX3uyT4QdM2UldffuGApNrF8e938MwNpDCK9CPoyxrEoCgT+hObJc3mZa6lQ==",
+            "version": "7.10.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.10.5.tgz",
+            "integrity": "sha512-0nkdeijB7VlZoLT3r/mY3bUkw3T8WG/hNw+FATs/6+pG2039IJWjTYL0VTISqsNHMUTEnwbVnc89WIJX9Qed0A==",
             "requires": {
                 "@babel/helper-function-name": "^7.10.4",
-                "@babel/helper-member-expression-to-functions": "^7.10.4",
+                "@babel/helper-member-expression-to-functions": "^7.10.5",
                 "@babel/helper-optimise-call-expression": "^7.10.4",
                 "@babel/helper-plugin-utils": "^7.10.4",
                 "@babel/helper-replace-supers": "^7.10.4",
@@ -149,13 +148,13 @@
             }
         },
         "@babel/helper-define-map": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.10.4.tgz",
-            "integrity": "sha512-nIij0oKErfCnLUCWaCaHW0Bmtl2RO9cN7+u2QT8yqTywgALKlyUVOvHDElh+b5DwVC6YB1FOYFOTWcN/+41EDA==",
+            "version": "7.10.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.10.5.tgz",
+            "integrity": "sha512-fMw4kgFB720aQFXSVaXr79pjjcW5puTCM16+rECJ/plGS+zByelE8l9nCpV1GibxTnFVmUuYG9U8wYfQHdzOEQ==",
             "requires": {
                 "@babel/helper-function-name": "^7.10.4",
-                "@babel/types": "^7.10.4",
-                "lodash": "^4.17.13"
+                "@babel/types": "^7.10.5",
+                "lodash": "^4.17.19"
             }
         },
         "@babel/helper-explode-assignable-expression": {
@@ -194,11 +193,11 @@
             }
         },
         "@babel/helper-member-expression-to-functions": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.10.4.tgz",
-            "integrity": "sha512-m5j85pK/KZhuSdM/8cHUABQTAslV47OjfIB9Cc7P+PvlAoBzdb79BGNfw8RhT5Mq3p+xGd0ZfAKixbrUZx0C7A==",
+            "version": "7.10.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.10.5.tgz",
+            "integrity": "sha512-HiqJpYD5+WopCXIAbQDG0zye5XYVvcO9w/DHp5GsaGkRUaamLj2bEtu6i8rnGGprAhHM3qidCMgp71HF4endhA==",
             "requires": {
-                "@babel/types": "^7.10.4"
+                "@babel/types": "^7.10.5"
             }
         },
         "@babel/helper-module-imports": {
@@ -210,17 +209,17 @@
             }
         },
         "@babel/helper-module-transforms": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.10.4.tgz",
-            "integrity": "sha512-Er2FQX0oa3nV7eM1o0tNCTx7izmQtwAQsIiaLRWtavAAEcskb0XJ5OjJbVrYXWOTr8om921Scabn4/tzlx7j1Q==",
+            "version": "7.10.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.10.5.tgz",
+            "integrity": "sha512-4P+CWMJ6/j1W915ITJaUkadLObmCRRSC234uctJfn/vHrsLNxsR8dwlcXv9ZhJWzl77awf+mWXSZEKt5t0OnlA==",
             "requires": {
                 "@babel/helper-module-imports": "^7.10.4",
                 "@babel/helper-replace-supers": "^7.10.4",
                 "@babel/helper-simple-access": "^7.10.4",
                 "@babel/helper-split-export-declaration": "^7.10.4",
                 "@babel/template": "^7.10.4",
-                "@babel/types": "^7.10.4",
-                "lodash": "^4.17.13"
+                "@babel/types": "^7.10.5",
+                "lodash": "^4.17.19"
             }
         },
         "@babel/helper-optimise-call-expression": {
@@ -237,11 +236,11 @@
             "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg=="
         },
         "@babel/helper-regex": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.10.4.tgz",
-            "integrity": "sha512-inWpnHGgtg5NOF0eyHlC0/74/VkdRITY9dtTpB2PrxKKn+AkVMRiZz/Adrx+Ssg+MLDesi2zohBW6MVq6b4pOQ==",
+            "version": "7.10.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.10.5.tgz",
+            "integrity": "sha512-68kdUAzDrljqBrio7DYAEgCoJHxppJOERHOgOrDN7WjOzP0ZQ1LsSDRXcemzVZaLvjaJsJEESb6qt+znNuENDg==",
             "requires": {
-                "lodash": "^4.17.13"
+                "lodash": "^4.17.19"
             }
         },
         "@babel/helper-remap-async-to-generator": {
@@ -321,14 +320,14 @@
             }
         },
         "@babel/parser": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.4.tgz",
-            "integrity": "sha512-8jHII4hf+YVDsskTF6WuMB3X4Eh+PsUkC2ljq22so5rHvH+T8BzyL94VOdyFLNR8tBSVXOTbNHOKpR4TfRxVtA=="
+            "version": "7.10.5",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.5.tgz",
+            "integrity": "sha512-wfryxy4bE1UivvQKSQDU4/X6dr+i8bctjUjj8Zyt3DQy7NtPizJXT8M52nqpNKL+nq2PW8lxk4ZqLj0fD4B4hQ=="
         },
         "@babel/plugin-proposal-async-generator-functions": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.10.4.tgz",
-            "integrity": "sha512-MJbxGSmejEFVOANAezdO39SObkURO5o/8b6fSH6D1pi9RZQt+ldppKPXfqgUWpSQ9asM6xaSaSJIaeWMDRP0Zg==",
+            "version": "7.10.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.10.5.tgz",
+            "integrity": "sha512-cNMCVezQbrRGvXJwm9fu/1sJj9bHdGAgKodZdLqOQIpfoH3raqmRPBM17+lh7CzhiKRRBrGtZL9WcjxSoGYUSg==",
             "requires": {
                 "@babel/helper-plugin-utils": "^7.10.4",
                 "@babel/helper-remap-async-to-generator": "^7.10.4",
@@ -575,12 +574,11 @@
             }
         },
         "@babel/plugin-transform-block-scoping": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.10.4.tgz",
-            "integrity": "sha512-J3b5CluMg3hPUii2onJDRiaVbPtKFPLEaV5dOPY5OeAbDi1iU/UbbFFTgwb7WnanaDy7bjU35kc26W3eM5Qa0A==",
+            "version": "7.10.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.10.5.tgz",
+            "integrity": "sha512-6Ycw3hjpQti0qssQcA6AMSFDHeNJ++R6dIMnpRqUjFeBBTmTDPa8zgF90OVfTvAo11mXZTlVUViY1g8ffrURLg==",
             "requires": {
-                "@babel/helper-plugin-utils": "^7.10.4",
-                "lodash": "^4.17.13"
+                "@babel/helper-plugin-utils": "^7.10.4"
             }
         },
         "@babel/plugin-transform-classes": {
@@ -683,11 +681,11 @@
             }
         },
         "@babel/plugin-transform-modules-amd": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.10.4.tgz",
-            "integrity": "sha512-3Fw+H3WLUrTlzi3zMiZWp3AR4xadAEMv6XRCYnd5jAlLM61Rn+CRJaZMaNvIpcJpQ3vs1kyifYvEVPFfoSkKOA==",
+            "version": "7.10.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.10.5.tgz",
+            "integrity": "sha512-elm5uruNio7CTLFItVC/rIzKLfQ17+fX7EVz5W0TMgIHFo1zY0Ozzx+lgwhL4plzl8OzVn6Qasx5DeEFyoNiRw==",
             "requires": {
-                "@babel/helper-module-transforms": "^7.10.4",
+                "@babel/helper-module-transforms": "^7.10.5",
                 "@babel/helper-plugin-utils": "^7.10.4",
                 "babel-plugin-dynamic-import-node": "^2.3.3"
             }
@@ -704,12 +702,12 @@
             }
         },
         "@babel/plugin-transform-modules-systemjs": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.10.4.tgz",
-            "integrity": "sha512-Tb28LlfxrTiOTGtZFsvkjpyjCl9IoaRI52AEU/VIwOwvDQWtbNJsAqTXzh+5R7i74e/OZHH2c2w2fsOqAfnQYQ==",
+            "version": "7.10.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.10.5.tgz",
+            "integrity": "sha512-f4RLO/OL14/FP1AEbcsWMzpbUz6tssRaeQg11RH1BP/XnPpRoVwgeYViMFacnkaw4k4wjRSjn3ip1Uw9TaXuMw==",
             "requires": {
                 "@babel/helper-hoist-variables": "^7.10.4",
-                "@babel/helper-module-transforms": "^7.10.4",
+                "@babel/helper-module-transforms": "^7.10.5",
                 "@babel/helper-plugin-utils": "^7.10.4",
                 "babel-plugin-dynamic-import-node": "^2.3.3"
             }
@@ -749,9 +747,9 @@
             }
         },
         "@babel/plugin-transform-parameters": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.10.4.tgz",
-            "integrity": "sha512-RurVtZ/D5nYfEg0iVERXYKEgDFeesHrHfx8RT05Sq57ucj2eOYAP6eu5fynL4Adju4I/mP/I6SO0DqNWAXjfLQ==",
+            "version": "7.10.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.10.5.tgz",
+            "integrity": "sha512-xPHwUj5RdFV8l1wuYiu5S9fqWGM2DrYc24TMvUiRrPVm+SM3XeqU9BcokQX/kEUe+p2RBwy+yoiR1w/Blq6ubw==",
             "requires": {
                 "@babel/helper-get-function-arity": "^7.10.4",
                 "@babel/helper-plugin-utils": "^7.10.4"
@@ -812,9 +810,9 @@
             }
         },
         "@babel/plugin-transform-react-jsx-source": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.10.4.tgz",
-            "integrity": "sha512-FTK3eQFrPv2aveerUSazFmGygqIdTtvskG50SnGnbEUnRPcGx2ylBhdFIzoVS1ty44hEgcPoCAyw5r3VDEq+Ug==",
+            "version": "7.10.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.10.5.tgz",
+            "integrity": "sha512-wTeqHVkN1lfPLubRiZH3o73f4rfon42HpgxUSs86Nc+8QIcm/B9s8NNVXu/gwGcOyd7yDib9ikxoDLxJP0UiDA==",
             "requires": {
                 "@babel/helper-plugin-utils": "^7.10.4",
                 "@babel/plugin-syntax-jsx": "^7.10.4"
@@ -889,9 +887,9 @@
             }
         },
         "@babel/plugin-transform-template-literals": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.10.4.tgz",
-            "integrity": "sha512-4NErciJkAYe+xI5cqfS8pV/0ntlY5N5Ske/4ImxAVX7mk9Rxt2bwDTGv1Msc2BRJvWQcmYEC+yoMLdX22aE4VQ==",
+            "version": "7.10.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.10.5.tgz",
+            "integrity": "sha512-V/lnPGIb+KT12OQikDvgSuesRX14ck5FfJXt6+tXhdkJ+Vsd0lDCVtF6jcB4rNClYFzaB2jusZ+lNISDk2mMMw==",
             "requires": {
                 "@babel/helper-annotate-as-pure": "^7.10.4",
                 "@babel/helper-plugin-utils": "^7.10.4"
@@ -906,11 +904,11 @@
             }
         },
         "@babel/plugin-transform-typescript": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.10.4.tgz",
-            "integrity": "sha512-3WpXIKDJl/MHoAN0fNkSr7iHdUMHZoppXjf2HJ9/ed5Xht5wNIsXllJXdityKOxeA3Z8heYRb1D3p2H5rfCdPw==",
+            "version": "7.10.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.10.5.tgz",
+            "integrity": "sha512-YCyYsFrrRMZ3qR7wRwtSSJovPG5vGyG4ZdcSAivGwTfoasMp3VOB/AKhohu3dFtmB4cCDcsndCSxGtrdliCsZQ==",
             "requires": {
-                "@babel/helper-create-class-features-plugin": "^7.10.4",
+                "@babel/helper-create-class-features-plugin": "^7.10.5",
                 "@babel/helper-plugin-utils": "^7.10.4",
                 "@babel/plugin-syntax-typescript": "^7.10.4"
             }
@@ -1046,17 +1044,17 @@
             }
         },
         "@babel/runtime": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.4.tgz",
-            "integrity": "sha512-UpTN5yUJr9b4EX2CnGNWIvER7Ab83ibv0pcvvHc4UOdrBI5jb8bj+32cCwPX6xu0mt2daFNjYhoi+X7beH0RSw==",
+            "version": "7.10.5",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.5.tgz",
+            "integrity": "sha512-otddXKhdNn7d0ptoFRHtMLa8LqDxLYwTjB4nYgM1yy5N6gU/MUf8zqyyLltCH3yAVitBzmwK4us+DD0l/MauAg==",
             "requires": {
                 "regenerator-runtime": "^0.13.4"
             }
         },
         "@babel/runtime-corejs3": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.10.4.tgz",
-            "integrity": "sha512-BFlgP2SoLO9HJX9WBwN67gHWMBhDX/eDz64Jajd6mR/UAUzqrNMm99d4qHnVaKscAElZoFiPv+JpR/Siud5lXw==",
+            "version": "7.10.5",
+            "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.10.5.tgz",
+            "integrity": "sha512-RMafpmrNB5E/bwdSphLr8a8++9TosnyJp98RZzI6VOx2R2CCMpsXXXRvmI700O9oEKpXdZat6oEK68/F0zjd4A==",
             "requires": {
                 "core-js-pure": "^3.0.0",
                 "regenerator-runtime": "^0.13.4"
@@ -1073,28 +1071,28 @@
             }
         },
         "@babel/traverse": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.10.4.tgz",
-            "integrity": "sha512-aSy7p5THgSYm4YyxNGz6jZpXf+Ok40QF3aA2LyIONkDHpAcJzDUqlCKXv6peqYUs2gmic849C/t2HKw2a2K20Q==",
+            "version": "7.10.5",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.10.5.tgz",
+            "integrity": "sha512-yc/fyv2gUjPqzTz0WHeRJH2pv7jA9kA7mBX2tXl/x5iOE81uaVPuGPtaYk7wmkx4b67mQ7NqI8rmT2pF47KYKQ==",
             "requires": {
                 "@babel/code-frame": "^7.10.4",
-                "@babel/generator": "^7.10.4",
+                "@babel/generator": "^7.10.5",
                 "@babel/helper-function-name": "^7.10.4",
                 "@babel/helper-split-export-declaration": "^7.10.4",
-                "@babel/parser": "^7.10.4",
-                "@babel/types": "^7.10.4",
+                "@babel/parser": "^7.10.5",
+                "@babel/types": "^7.10.5",
                 "debug": "^4.1.0",
                 "globals": "^11.1.0",
-                "lodash": "^4.17.13"
+                "lodash": "^4.17.19"
             }
         },
         "@babel/types": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.4.tgz",
-            "integrity": "sha512-UTCFOxC3FsFHb7lkRMVvgLzaRVamXuAs2Tz4wajva4WxtVY82eZeaUBtC2Zt95FU9TiznuC0Zk35tsim8jeVpg==",
+            "version": "7.10.5",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.5.tgz",
+            "integrity": "sha512-ixV66KWfCI6GKoA/2H9v6bQdbfXEwwpOdQ8cRvb4F+eyvhlaHxWFMQB4+3d9QFJXZsiiiqVrewNV0DFEQpyT4Q==",
             "requires": {
                 "@babel/helper-validator-identifier": "^7.10.4",
-                "lodash": "^4.17.13",
+                "lodash": "^4.17.19",
                 "to-fast-properties": "^2.0.0"
             }
         },
@@ -1233,16 +1231,6 @@
                 "@firebase/util": "0.2.50",
                 "faye-websocket": "0.11.3",
                 "tslib": "^1.11.1"
-            },
-            "dependencies": {
-                "faye-websocket": {
-                    "version": "0.11.3",
-                    "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.3.tgz",
-                    "integrity": "sha512-D2y4bovYpzziGgbHYtGCMjlJM36vAl/y+xUyn1C+FVx8szd1E+86KwVw6XvYSzOP8iMpm1X0I4xJD+QtUb36OA==",
-                    "requires": {
-                        "websocket-driver": ">=0.5.1"
-                    }
-                }
             }
         },
         "@firebase/database-types": {
@@ -1884,6 +1872,11 @@
                         "@types/yargs-parser": "*"
                     }
                 },
+                "ansi-regex": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+                },
                 "ansi-styles": {
                     "version": "4.2.1",
                     "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
@@ -1891,15 +1884,6 @@
                     "requires": {
                         "@types/color-name": "^1.1.1",
                         "color-convert": "^2.0.1"
-                    }
-                },
-                "aria-query": {
-                    "version": "4.2.2",
-                    "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-4.2.2.tgz",
-                    "integrity": "sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==",
-                    "requires": {
-                        "@babel/runtime": "^7.10.2",
-                        "@babel/runtime-corejs3": "^7.10.2"
                     }
                 },
                 "chalk": {
@@ -2075,9 +2059,9 @@
             "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA=="
         },
         "@types/node": {
-            "version": "14.0.23",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.23.tgz",
-            "integrity": "sha512-Z4U8yDAl5TFkmYsZdFPdjeMa57NOvnaf1tljHzhouaPEp7LCj2JKkejpI1ODviIAQuW4CcQmxkQ77rnLsOOoKw=="
+            "version": "13.13.14",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.14.tgz",
+            "integrity": "sha512-Az3QsOt1U/K1pbCQ0TXGELTuTkPLOiFIQf3ILzbOyo0FqgV9SxRnxbxM5QlAveERZMHpZY+7u3Jz2tKyl+yg6g=="
         },
         "@types/parse-json": {
             "version": "4.0.0",
@@ -2152,6 +2136,11 @@
                     "requires": {
                         "@types/yargs-parser": "*"
                     }
+                },
+                "ansi-regex": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
                 },
                 "ansi-styles": {
                     "version": "4.2.1",
@@ -2598,9 +2587,9 @@
             "integrity": "sha1-gTWEAhliqenm/QOflA0S9WynhZ4="
         },
         "ansi-regex": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-            "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+            "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
         },
         "ansi-styles": {
             "version": "3.2.1",
@@ -2633,12 +2622,12 @@
             }
         },
         "aria-query": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-3.0.0.tgz",
-            "integrity": "sha1-ZbP8wcoRVajJrmTW7uKX8V1RM8w=",
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-4.2.2.tgz",
+            "integrity": "sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==",
             "requires": {
-                "ast-types-flow": "0.0.7",
-                "commander": "^2.11.0"
+                "@babel/runtime": "^7.10.2",
+                "@babel/runtime-corejs3": "^7.10.2"
             }
         },
         "arity-n": {
@@ -3880,6 +3869,12 @@
                     "requires": {
                         "to-regex-range": "^5.0.1"
                     }
+                },
+                "fsevents": {
+                    "version": "2.1.3",
+                    "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+                    "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+                    "optional": true
                 },
                 "is-number": {
                     "version": "7.0.0",
@@ -5289,9 +5284,9 @@
             }
         },
         "electron-to-chromium": {
-            "version": "1.3.496",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.496.tgz",
-            "integrity": "sha512-TXY4mwoyowwi4Lsrq9vcTUYBThyc1b2hXaTZI13p8/FRhY2CTaq5lK+DVjhYkKiTLsKt569Xes+0J5JsVXFurQ=="
+            "version": "1.3.497",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.497.tgz",
+            "integrity": "sha512-sPdW5bUDZwiFtoonuZCUwRGzsZmKzcLM0bMVhp6SMCfUG+B3faENLx3cE+o+K0Jl+MPuNA9s9cScyFjOlixZpQ=="
         },
         "elliptic": {
             "version": "6.5.3",
@@ -5490,9 +5485,9 @@
             }
         },
         "escalade": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.0.1.tgz",
-            "integrity": "sha512-DR6NO3h9niOT+MZs7bjxlj2a1k+POu5RN8CLTPX2+i78bRi9eLe7+0zXgUHMnGXWybYcL61E9hGhPKqedy8tQA=="
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.0.2.tgz",
+            "integrity": "sha512-gPYAU37hYCUhW5euPeR+Y74F7BL+IBsV93j5cvGriSaD1aG6MGsqsV1yamRdrWrb2j3aiZvb0X+UBOWpx3JWtQ=="
         },
         "escape-html": {
             "version": "1.0.3",
@@ -5875,6 +5870,15 @@
                 "jsx-ast-utils": "^2.2.1"
             },
             "dependencies": {
+                "aria-query": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-3.0.0.tgz",
+                    "integrity": "sha1-ZbP8wcoRVajJrmTW7uKX8V1RM8w=",
+                    "requires": {
+                        "ast-types-flow": "0.0.7",
+                        "commander": "^2.11.0"
+                    }
+                },
                 "emoji-regex": {
                     "version": "7.0.3",
                     "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
@@ -6163,6 +6167,11 @@
                     "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
                     "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
                 },
+                "path-to-regexp": {
+                    "version": "0.1.7",
+                    "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+                    "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+                },
                 "qs": {
                     "version": "6.7.0",
                     "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
@@ -6367,9 +6376,9 @@
             "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
         },
         "faye-websocket": {
-            "version": "0.10.0",
-            "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
-            "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
+            "version": "0.11.3",
+            "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.3.tgz",
+            "integrity": "sha512-D2y4bovYpzziGgbHYtGCMjlJM36vAl/y+xUyn1C+FVx8szd1E+86KwVw6XvYSzOP8iMpm1X0I4xJD+QtUb36OA==",
             "requires": {
                 "websocket-driver": ">=0.5.1"
             }
@@ -6748,10 +6757,14 @@
             "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
         },
         "fsevents": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
-            "integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
-            "optional": true
+            "version": "1.2.13",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
+            "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+            "optional": true,
+            "requires": {
+                "bindings": "^1.5.0",
+                "nan": "^2.12.1"
+            }
         },
         "function-bind": {
             "version": "1.1.1",
@@ -7644,6 +7657,11 @@
                 "through": "^2.3.6"
             },
             "dependencies": {
+                "ansi-regex": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+                },
                 "ansi-styles": {
                     "version": "4.2.1",
                     "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
@@ -8300,18 +8318,6 @@
                 "micromatch": "^3.1.10",
                 "sane": "^4.0.3",
                 "walker": "^1.0.7"
-            },
-            "dependencies": {
-                "fsevents": {
-                    "version": "1.2.13",
-                    "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
-                    "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-                    "optional": true,
-                    "requires": {
-                        "bindings": "^1.5.0",
-                        "nan": "^2.12.1"
-                    }
-                }
             }
         },
         "jest-jasmine2": {
@@ -9552,9 +9558,9 @@
             }
         },
         "mri": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/mri/-/mri-1.1.5.tgz",
-            "integrity": "sha512-d2RKzMD4JNyHMbnbWnznPaa8vbdlq/4pNZ3IgdaGrVbBhebBsGUUE/6qorTMYNS6TwuH3ilfOlD2bf4Igh8CKg==",
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/mri/-/mri-1.1.6.tgz",
+            "integrity": "sha512-oi1b3MfbyGa7FJMP9GmLTttni5JoICpYBRlq+x5V16fZbLsnL9N3wFqqIm/nIG43FjUFkFh9Epzp/kzUGUnJxQ==",
             "dev": true
         },
         "ms": {
@@ -10341,9 +10347,19 @@
             "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
         },
         "path-to-regexp": {
-            "version": "0.1.7",
-            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-            "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+            "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+            "requires": {
+                "isarray": "0.0.1"
+            },
+            "dependencies": {
+                "isarray": {
+                    "version": "0.0.1",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+                }
+            }
         },
         "path-type": {
             "version": "3.0.0",
@@ -11434,13 +11450,6 @@
                 "ansi-regex": "^4.0.0",
                 "ansi-styles": "^3.2.0",
                 "react-is": "^16.8.4"
-            },
-            "dependencies": {
-                "ansi-regex": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-                    "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
-                }
             }
         },
         "pretty-quick": {
@@ -11664,13 +11673,6 @@
                 "@types/long": "^4.0.1",
                 "@types/node": "^13.7.0",
                 "long": "^4.0.0"
-            },
-            "dependencies": {
-                "@types/node": {
-                    "version": "13.13.14",
-                    "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.14.tgz",
-                    "integrity": "sha512-Az3QsOt1U/K1pbCQ0TXGELTuTkPLOiFIQf3ILzbOyo0FqgV9SxRnxbxM5QlAveERZMHpZY+7u3Jz2tKyl+yg6g=="
-                }
             }
         },
         "proxy-addr": {
@@ -11686,6 +11688,11 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
             "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
+        },
+        "ps-list": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/ps-list/-/ps-list-7.2.0.tgz",
+            "integrity": "sha512-v4Bl6I3f2kJfr5o80ShABNHAokIgY+wFDTQfE+X3zWYgSGQOCBeYptLZUpoOALBqO5EawmDN/tjTldJesd0ujQ=="
         },
         "psl": {
             "version": "1.8.0",
@@ -11897,11 +11904,6 @@
                         "@babel/highlight": "^7.8.3"
                     }
                 },
-                "ansi-regex": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-                    "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
-                },
                 "browserslist": {
                     "version": "4.10.0",
                     "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.10.0.tgz",
@@ -12095,21 +12097,6 @@
                 "react-is": "^16.6.0",
                 "tiny-invariant": "^1.0.2",
                 "tiny-warning": "^1.0.0"
-            },
-            "dependencies": {
-                "isarray": {
-                    "version": "0.0.1",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-                },
-                "path-to-regexp": {
-                    "version": "1.8.0",
-                    "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
-                    "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
-                    "requires": {
-                        "isarray": "0.0.1"
-                    }
-                }
             }
         },
         "react-router-dom": {
@@ -13175,6 +13162,16 @@
             "requires": {
                 "faye-websocket": "^0.10.0",
                 "uuid": "^3.0.1"
+            },
+            "dependencies": {
+                "faye-websocket": {
+                    "version": "0.10.0",
+                    "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
+                    "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
+                    "requires": {
+                        "websocket-driver": ">=0.5.1"
+                    }
+                }
             }
         },
         "sockjs-client": {
@@ -13196,14 +13193,6 @@
                     "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
                     "requires": {
                         "ms": "^2.1.1"
-                    }
-                },
-                "faye-websocket": {
-                    "version": "0.11.3",
-                    "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.3.tgz",
-                    "integrity": "sha512-D2y4bovYpzziGgbHYtGCMjlJM36vAl/y+xUyn1C+FVx8szd1E+86KwVw6XvYSzOP8iMpm1X0I4xJD+QtUb36OA==",
-                    "requires": {
-                        "websocket-driver": ">=0.5.1"
                     }
                 }
             }
@@ -13517,6 +13506,11 @@
                 "strip-ansi": "^6.0.0"
             },
             "dependencies": {
+                "ansi-regex": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+                },
                 "strip-ansi": {
                     "version": "6.0.0",
                     "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
@@ -13596,13 +13590,6 @@
             "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
             "requires": {
                 "ansi-regex": "^4.1.0"
-            },
-            "dependencies": {
-                "ansi-regex": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-                    "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
-                }
             }
         },
         "strip-bom": {
@@ -14528,16 +14515,6 @@
                         "upath": "^1.1.1"
                     }
                 },
-                "fsevents": {
-                    "version": "1.2.13",
-                    "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
-                    "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-                    "optional": true,
-                    "requires": {
-                        "bindings": "^1.5.0",
-                        "nan": "^2.12.1"
-                    }
-                },
                 "glob-parent": {
                     "version": "3.1.0",
                     "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
@@ -14843,16 +14820,6 @@
                                 "ansi-regex": "^3.0.0"
                             }
                         }
-                    }
-                },
-                "fsevents": {
-                    "version": "1.2.13",
-                    "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
-                    "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-                    "optional": true,
-                    "requires": {
-                        "bindings": "^1.5.0",
-                        "nan": "^2.12.1"
                     }
                 },
                 "get-caller-file": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
         "postcss-normalize": "8.0.1",
         "postcss-preset-env": "6.7.0",
         "postcss-safe-parser": "4.0.1",
+        "ps-list": "^7.2.0",
         "react": "^16.13.1",
         "react-app-polyfill": "^1.0.6",
         "react-dev-utils": "^10.2.1",

--- a/src/App.js
+++ b/src/App.js
@@ -3,6 +3,7 @@ import styled, { css } from "styled-components";
 import LoginComponent from "./apps/Login";
 import RegistrationComponent from "./apps/Registration";
 import { BrowserRouter as Router, Switch, Route } from "react-router-dom";
+import RunningProcesses from "./components/RunningProcesses";
 
 const Background = styled.div`
     ${(props) =>
@@ -25,6 +26,9 @@ function App() {
                     </Route>
                     <Route exact path="/">
                         <LoginComponent />
+                    </Route>
+                    <Route path="/processes">
+                        <RunningProcesses />
                     </Route>
                 </Background>
             </Switch>

--- a/src/components/RunningProcesses.jsx
+++ b/src/components/RunningProcesses.jsx
@@ -6,16 +6,21 @@ const RunningProcesses = () => {
 
     // handleRequestProcessesPress is called when a user clicks the "Request
     // Processes" button. This sends a message to the main Electron process.
-    const handleRequestProcessesPress = () =>
-        electron.ipcRenderer.send("processesRequest", null);
+    const handleRequestProcessesPress = async () => {
+        const processesList = await electron.ipcRenderer.invoke(
+            "processesRequest",
+            null,
+        );
+        setRunningProcesses(processesList);
+    };
 
     // Handle messages from the main Electron process about what processes are
     // running on the user's machine. These messages from the main Electron
     // process will be sent in response to the "processesRequest" message being
     // sent by the front-end.
-    electron.ipcRenderer.on("processesReply", (_event, arg) =>
-        setRunningProcesses(arg),
-    );
+    // electron.ipcRenderer.on("processesReply", (_event, arg) =>
+    //     setRunningProcesses(arg),
+    // );
 
     return (
         <>
@@ -23,7 +28,7 @@ const RunningProcesses = () => {
             {runningProcesses.map((process) => (
                 <p>{process}</p>
             ))}
-            <button onClick={handleRequestProcessesPress}>
+            <button onClick={async () => await handleRequestProcessesPress()}>
                 Request Processes
             </button>
         </>

--- a/src/components/RunningProcesses.jsx
+++ b/src/components/RunningProcesses.jsx
@@ -1,0 +1,33 @@
+import React, { useState } from "react";
+const electron = window.require("electron");
+
+const RunningProcesses = () => {
+    const [runningProcesses, setRunningProcesses] = useState([""]);
+
+    // handleRequestProcessesPress is called when a user clicks the "Request
+    // Processes" button. This sends a message to the main Electron process.
+    const handleRequestProcessesPress = () =>
+        electron.ipcRenderer.send("processesRequest", null);
+
+    // Handle messages from the main Electron process about what processes are
+    // running on the user's machine. These messages from the main Electron
+    // process will be sent in response to the "processesRequest" message being
+    // sent by the front-end.
+    electron.ipcRenderer.on("processesReply", (_event, arg) =>
+        setRunningProcesses(arg),
+    );
+
+    return (
+        <>
+            <h2>Running Processes:</h2>
+            {runningProcesses.map((process) => (
+                <p>{process}</p>
+            ))}
+            <button onClick={handleRequestProcessesPress}>
+                Request Processes
+            </button>
+        </>
+    );
+};
+
+export default RunningProcesses;

--- a/src/components/RunningProcesses.jsx
+++ b/src/components/RunningProcesses.jsx
@@ -5,11 +5,15 @@ const RunningProcesses = () => {
     const [runningProcesses, setRunningProcesses] = useState([""]);
 
     // handleRequestProcessesPress is called when a user clicks the "Request
-    // Processes" button. This sends a message to the main Electron process.
+    // Processes" button. This sends a message to the main Electron process, and
+    // formats the response into something fit for displaying to the user.
     const handleRequestProcessesPress = async () => {
-        const processesList = await electron.ipcRenderer.invoke(
+        let processesList = await electron.ipcRenderer.invoke(
             "processesRequest",
             null,
+        );
+        processesList = processesList.map(
+            (process) => `${process.name} (PID: ${process.pid})`,
         );
         setRunningProcesses(processesList);
     };


### PR DESCRIPTION
### New Functionality

This PR introduces an event listener that runs on the main Electron process which, when invoked, fetches all of the processes that are running on a user's machine. This event listener can be invoked by the front-end. When invoked, this handler responds asynchronously. If everything goes according to plan, the handler responds with a list of strings, each containing information about a running process.

### Error Handling

Currently, error-handling is 💩 . If anything goes wrong during the process-fetching process (lol), instead of returning a list of process information, the handler responds with a list of strings containing any relevant information about the error that occurred. I haven't thought much about better ways to pass errors up to the front-end. Please lmk what your thoughts are on this, and suggest your ideas for improving this strategy.

### Thoughts for the Future

At least on my machine, when I fetch all of the running processes, I get a list of ~450 items. That's ridiculous; there's no way we should display that many processes to users when they're configuring their custom rules to set their "availability status" in our app.

We should talk about approaches to trimming down the size of this list, cherry-picking out the relevant processes that we think users would like to see. Perhaps, for the sake of the hackathon, we could put together a whitelist of process names that represent popular programs that our users might be running?