### PR TITLE
Use IPC without enabling Node integration

### DIFF
--- a/main.js
+++ b/main.js
@@ -7,7 +7,7 @@ function createWindow() {
         width: 800,
         height: 900,
         webPreferences: {
-            nodeIntegration: true,
+            preload: __dirname + "/preload.js",
         },
         icon: "tokspace.png",
         title: "TokSpace",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,10 @@
         "test": "node scripts/test.js"
     },
     "eslintConfig": {
-        "extends": "react-app"
+        "extends": "react-app",
+        "globals": {
+            "ipcRenderer": "readonly"
+        }
     },
     "browserslist": {
         "production": [

--- a/preload.js
+++ b/preload.js
@@ -1,0 +1,1 @@
+window.ipcRenderer = require("electron").ipcRenderer;

--- a/src/App.js
+++ b/src/App.js
@@ -27,9 +27,6 @@ function App() {
                     <Route exact path="/">
                         <LoginComponent />
                     </Route>
-                    <Route path="/processes">
-                        <RunningProcesses />
-                    </Route>
                 </Background>
             </Switch>
         </Router>

--- a/src/components/RunningProcesses.jsx
+++ b/src/components/RunningProcesses.jsx
@@ -1,5 +1,4 @@
 import React, { useState } from "react";
-const electron = window.require("electron");
 
 const RunningProcesses = () => {
     const [runningProcesses, setRunningProcesses] = useState([""]);
@@ -8,10 +7,7 @@ const RunningProcesses = () => {
     // Processes" button. This sends a message to the main Electron process, and
     // formats the response into something fit for displaying to the user.
     const handleRequestProcessesPress = async () => {
-        let processesList = await electron.ipcRenderer.invoke(
-            "processesRequest",
-            null,
-        );
+        let processesList = await ipcRenderer.invoke("processesRequest", null);
         processesList = processesList.map(
             (process) => `${process.name} (PID: ${process.pid})`,
         );


### PR DESCRIPTION
Using a `preload` script we can use the IPC functions without needing `nodeIntegration` enabled.