### PR TITLE
Configure title bar traffic lights to look more modern

### DIFF
--- a/main.js
+++ b/main.js
@@ -6,6 +6,7 @@ function createWindow() {
     const win = new BrowserWindow({
         width: 800,
         height: 900,
+        titleBarStyle: "hiddenInset",
         webPreferences: {
             preload: __dirname + "/preload.js",
         },


### PR DESCRIPTION
**Purely aesthetic change.** I found a configuration that you can include in the object that's passed into `new BrowserWindow()` which makes the title bar look more like that of modern, native macOS applications.

What you do you all think?

_Note_: I've only tested on macOS and a flavor of Linux. I don't have access to a Windows machine to see if this change breaks anything there. The screenshots below show what this change looks like on macOS. On Linux (at least a flavor with the GNOME desktop environment), the title bar looks no different after this change.

**Old title bar**:
<img width="912" alt="old" src="https://user-images.githubusercontent.com/31291920/87588206-448fb080-c6b1-11ea-8086-71454f2676ab.png">

**New title bar**:
<img width="912" alt="new" src="https://user-images.githubusercontent.com/31291920/87588260-56715380-c6b1-11ea-8bab-546e80ccd9e1.png">

