### PR TITLE
Introduce barebones functionality on settings page

### DIFF
--- a/main.js
+++ b/main.js
@@ -78,7 +78,7 @@ function parseDataFile(filePath, defaults) {
 const store = new Store({
     configName: "user-configs",
     defaults: {
-        storedProcesses: ["one", "two", "three"],
+        storedProcesses: [],
     },
 });
 

--- a/main.js
+++ b/main.js
@@ -93,6 +93,6 @@ ipcMain.handle("configuredProcessesRequest", () =>
 ipcMain.handle(
     "saveNewConfiguredProcesses",
     (_event, newConfiguredProcesses) => {
-        store.set(newConfiguredProcesses);
+        store.set("storedProcesses", newConfiguredProcesses);
     },
 );

--- a/main.js
+++ b/main.js
@@ -1,4 +1,6 @@
-const { app, BrowserWindow, ipcMain } = require("electron");
+const { app, BrowserWindow, ipcMain, remote } = require("electron");
+const path = require("path");
+const fs = require("fs");
 const psList = require("ps-list");
 
 function createWindow() {
@@ -23,3 +25,74 @@ app.whenReady().then(createWindow);
 // Listen for the front-end web app to send a request that asks for what
 // processes are running on the user's machine.
 ipcMain.handle("processesRequest", async () => psList());
+
+class Store {
+    // opts is an object with the following structure:
+    //
+    // {
+    //   // The name of the file on local storage where user configs are stored.
+    //   configName: string,
+    //
+    //   // Default user configs. To be used if something goes wrong reading the
+    //   // local file on disk with these configs.
+    //   defaults: {
+    //     // Process names that the user has configred to set their
+    //     // availability status to "away" when running.
+    //     storedProcesses: [],
+    //   },
+    // }
+    constructor(opts) {
+        // Renderer process has to get `app` module via `remote`, whereas the
+        // main process can get it directly.
+        const userDataPath = (app || remote.app).getPath("userData");
+        this.path = path.join(userDataPath, opts.configName + ".json");
+        console.log(this.path);
+
+        this.data = parseDataFile(this.path, opts.defaults);
+    }
+
+    get(key) {
+        return this.data[key];
+    }
+
+    set(key, val) {
+        this.data[key] = val;
+
+        try {
+            fs.writeFileSync(this.path, JSON.stringify(this.data));
+        } catch (err) {
+            // TODO: better error handling.
+            console.error(err);
+        }
+    }
+}
+
+function parseDataFile(filePath, defaults) {
+    try {
+        return JSON.parse(fs.readFileSync(filePath));
+    } catch (error) {
+        return defaults;
+    }
+}
+
+const store = new Store({
+    configName: "user-configs",
+    defaults: {
+        storedProcesses: ["one", "two", "three"],
+    },
+});
+
+// Listen for the front-end web app to send a request that asks for what
+// processes the user's already configured in the settings page.
+ipcMain.handle("configuredProcessesRequest", () =>
+    store.get("storedProcesses"),
+);
+
+// Listen for the front-end web app to push up new configured processes that the
+// user has configured.
+ipcMain.handle(
+    "saveNewConfiguredProcesses",
+    (_event, newConfiguredProcesses) => {
+        store.set(newConfiguredProcesses);
+    },
+);

--- a/src/App.js
+++ b/src/App.js
@@ -16,6 +16,7 @@ import PropTypes from "prop-types";
 import Dashboard from "./apps/Dashboard";
 import { NewPeer } from "./websockets/Connection";
 import SessionInitiator from "./apps/SessionInitiator";
+import Settings from "./apps/Settings";
 
 const Background = styled.div`
     ${(props) =>
@@ -87,6 +88,9 @@ function App() {
                         <Background>
                             <OfficeView />
                         </Background>
+                    </Route>
+                    <Route path="/settings">
+                        <Settings />
                     </Route>
                     <Redirect to="/dashboard" />
                 </Switch>

--- a/src/apps/OfficeView.js
+++ b/src/apps/OfficeView.js
@@ -46,6 +46,12 @@ export default function () {
             <Button to="/" className="lt-button lt-hover" onClick={signout}>
                 Signout
             </Button>
+            <Button
+                to="/settings"
+                className="lt-button lt-hover"
+                onClick={() => history.push("/settings")}>
+                Settings
+            </Button>
         </Card>
     );
 }

--- a/src/apps/Settings.js
+++ b/src/apps/Settings.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from "react";
+import { useHistory } from "react-router-dom";
 import { Card } from "../styled/Card";
 import { Button } from "../components/Inputs";
 
@@ -6,6 +7,8 @@ const Settings = () => {
     const [storedProcesses, setStoredProcesses] = useState([""]);
     const [runningProcesses, setRunningProcesses] = useState([]);
     const [newProcessToAdd, setNewProcessToAdd] = useState("");
+
+    const history = useHistory();
 
     useEffect(() => {
         // Fetch configured processes from local storage.
@@ -78,6 +81,11 @@ const Settings = () => {
                     </Button>
                 </>
             )}
+            <Button
+                className="lt-button lt-hover"
+                onClick={() => history.goBack()}>
+                Back
+            </Button>
         </Card>
     );
 };

--- a/src/apps/Settings.js
+++ b/src/apps/Settings.js
@@ -1,0 +1,41 @@
+import React, { useState, useEffect } from "react";
+import { Card } from "../styled/Card";
+
+const Settings = () => {
+    const [storedProcesses, setStoredProcesses] = useState([""]);
+    // const [runningProcesses, setRunningProcesses] = useState([""]);
+
+    useEffect(() => {
+        // Fetch configured processes from local storage.
+        //
+        // We shouldn't have problems with race conditions by doing this because
+        // no one else is interested in these data. This is still disgusting and
+        // I'm really sorry.
+        async function fetchProcessesOnDisk() {
+            const loadedProcesses = await ipcRenderer.invoke(
+                "configuredProcessesRequest",
+                null,
+            );
+            setStoredProcesses(loadedProcesses);
+            console.log(loadedProcesses);
+        }
+        fetchProcessesOnDisk();
+    }, []);
+
+    // TODO: write a button handler which asks for all running processes.
+
+    return (
+        <Card className="lt-card lt-shadow">
+            <h2>Settings</h2>
+            <h3>Availability Status</h3>
+            {storedProcesses.map((process) => (
+                <p>{process}</p>
+            ))}
+            <p className="subtext">
+                Add a new one! Dropdown will live here soon.
+            </p>
+        </Card>
+    );
+};
+
+export default Settings;

--- a/src/apps/Settings.js
+++ b/src/apps/Settings.js
@@ -50,11 +50,17 @@ const Settings = () => {
                 <p key={process}>{process}</p>
             ))}
             {runningProcesses.length <= 0 && (
-                <Button
-                    className="lt-button lt-hover"
-                    onClick={async () => await handleChooseANewProcess()}>
-                    Add a New Process
-                </Button>
+                <>
+                    <p className="subtext">
+                        You haven't configured your availability status to
+                        change if any processes are running.
+                    </p>
+                    <Button
+                        className="lt-button lt-hover"
+                        onClick={async () => await handleChooseANewProcess()}>
+                        Add a New Process
+                    </Button>
+                </>
             )}
             {runningProcesses.length > 0 && (
                 <>

--- a/src/websockets/Connection.js
+++ b/src/websockets/Connection.js
@@ -21,10 +21,10 @@ export function NewPeer(user, isInitiator = false, target = undefined) {
             };
 
             ws.onopen = () => {
+                p = new Peer({ initiator: isInitiator, stream });
                 if (isInitiator) {
                     console.log("initiating connection as initiator");
                     ws.send(user.uid);
-                    p = new Peer({ initiator: isInitiator, stream });
                     p.on("signal", (data) => {
                         const payload = {
                             target: target,


### PR DESCRIPTION
User-configured processes are saved to a file on disk. On macOS, this file is located at `/Users/nick/Library/Application Support/Electron/user-configs.json`. See the new `Store` class in `main.js` for more information about how settings are persisted locally.

I'm exercising lots of "bad practices" in this PR. Let's ignore those for the sake of the hackathon 😉 