### PR TITLE
Use profile snapshots instead of a single fetch

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -48,8 +48,7 @@ function App() {
             firebase
                 .firestore()
                 .doc(`Users/${firebaseUser.uid}`)
-                .get()
-                .then((snapshot) => {
+                .onSnapshot((snapshot) => {
                     setUser({
                         tokProfile: snapshot.data(),
                         ...firebaseUser,


### PR DESCRIPTION
Currently, the app tries to fetch the user's profile (which doesn't exist) when they log in due to account creation, and that causes an error once they are redirected to the dashboard after their profile is created.

This change will fix the user registration flow by updating the profile *before* the user is sent to their dashboard.